### PR TITLE
enable basic form validation

### DIFF
--- a/addClaim.html
+++ b/addClaim.html
@@ -191,7 +191,7 @@
             <p>All information is required unless it's listed as optional</p>
         </div>
         
-        <div class = "inputsWrap">
+        <form class = "inputsWrap" data-toggle="validator" role="form">
           <div class = "policyHolderContactInfo">
             <p class = "sectionHeader">Policyholder Contact Info</p>
             <div class = "inputRow">
@@ -309,7 +309,7 @@
 							</button>
           </div>
         </div>
-      </div>
+      </form>
   </body>
   <footer class="footer footer-medium">
     <div class="container">


### PR DESCRIPTION
## Problem

In summary, you need to have a `<form>` element with an attribute of `data-toggle="validator"` declared for the validation JavaScript to work as expected.

## References

> Projects using the full HIG UX KIT - we are using the [Bootstrap Validator](https://github.com/1000hz/bootstrap-validator) plugin. This plugin provides a easy, bootstrap-friendly method for validating and providing feedback in a way that is easy to customize.

_as per [HIG UX KIT : Form Validation](https://qawww.thehartford.com/sites/frontendstage/uxkit/demo/dist/form-validation.html)_


> Form validation can be enabled in markup via the data-api or via JavaScript. Automatically enable form validation by adding data-toggle="validator" to your form element.

```html
<form role="form" data-toggle="validator">
  ...
</form>
```

_as per [bootstrap-validator#validator-usage](http://1000hz.github.io/bootstrap-validator/#validator-usage)_